### PR TITLE
Fixed submodules path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "monero-gui"]
 	path = monero-gui
-	url = git@github.com:monero-project/monero-gui.git
+	url = git://github.com/monero-project/monero-gui.git


### PR DESCRIPTION
Fixes the following error when attempting submodule update.

fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.

